### PR TITLE
Allow for App Service Environment ID for App Service Plan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See http://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.66.0
     hooks:
     - id: terraform_fmt
     - id: terraform_docs
@@ -11,7 +11,7 @@ repos:
     # - id: terraform_tfsec
     # - id: checkov
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace

--- a/modules/webapps/asp/module.tf
+++ b/modules/webapps/asp/module.tf
@@ -28,7 +28,7 @@ resource "azurerm_app_service_plan" "asp" {
     capacity = lookup(var.settings.sku, "capacity", null)
   }
 
-  app_service_environment_id = var.app_service_environment_id
+  app_service_environment_id = try(var.settings.app_service_environment_id, var.app_service_environment_id)
   tags                       = local.tags
 
   timeouts {


### PR DESCRIPTION
Included check for app_service_environment_id from the App Service Plan's settings, otherwise defaults to var.app_service_environment_id.