### PR TITLE
Tags/5.5.5/crowe add support for standalone subnet key/main

### DIFF
--- a/app_services.tf
+++ b/app_services.tf
@@ -40,5 +40,9 @@ resource "azurerm_app_service_virtual_network_swift_connection" "vnet_config" {
   }
 
   app_service_id = module.app_services[each.key].id
-  subnet_id      = local.combined_objects_networking[try(each.value.vnet_integration.lz_key, local.client_config.landingzone_key)][each.value.vnet_integration.vnet_key].subnets[each.value.vnet_integration.subnet_key].id
+
+  subnet_id      = try(
+    local.combined_objects_networking[try(each.value.vnet_integration.lz_key, local.client_config.landingzone_key)][each.value.vnet_integration.vnet_key].subnets[each.value.vnet_integration.subnet_key].id, 
+    local.combined_objects_virtual_subnets[try(each.value.vnet_integration.lz_key, local.client_config.landingzone_key)][each.value.vnet_integration.subnet_key].id
+  )
 }

--- a/function_app.tf
+++ b/function_app.tf
@@ -28,7 +28,13 @@ module "function_apps" {
   tags = try(each.value.tags, null)
 
   remote_objects = {
-    subnets = try(local.combined_objects_networking[try(each.value.settings.lz_key, local.client_config.landingzone_key)][each.value.settings.vnet_key].subnets, null)
+    subnets = try(
+      local.combined_objects_networking[try(each.value.settings.lz_key, local.client_config.landingzone_key)][each.value.settings.vnet_key].subnets, 
+      try(
+        local.combined_objects_virtual_subnets[try(each.value.settings.lz_key, local.client_config.landingzone_key)], 
+        null
+      )
+    )
   }
 }
 


### PR DESCRIPTION
add the ability to lookup the subnet id from a stand-alone virtual_subnet when creating the association between an app service/function app and a vnet... previously it required that we needed to have the subnets defined within the vnet ... However, that doesn't work for scenarios where the vnet is managed outside of CAF (i.e. pre-existing).  This change allows the consumer to then leverage remote state to load up the virtual subnets and create the association without forcing them to create a vnet from scratch and defining the subnet on the vnet resource itself...   

**PBI:**  https://crowevs.visualstudio.com/Infrastructure/_boards/board/t/Cloud%20Delivery%20Team/Backlog%20items/?workitem=216013

**Task:**  https://crowevs.visualstudio.com/Infrastructure/_boards/board/t/Cloud%20Delivery%20Team/Backlog%20items/?workitem=217126